### PR TITLE
Fix the syntax in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All the scripts inside this repo need a `credentials.json` in their home folder 
 Syntax:
 
  ```
-php index.php $repoName generate:changelog $base $head --format=$format
+php index.php generate:changelog $repoName $base $head --format=$format
  ```
 
 The format setting has the following options:
@@ -34,13 +34,13 @@ The format setting has the following options:
 E.g. to generate the changelog for the upcoming 13.0.1 server release. This script automatically derives the milestone from the first argument "v13.0.0" will mean that the milestone "13.0.1" will be checked for pending pull requests:
 
 ```
-php index.php server generate:changelog v13.0.0 stable13
+php index.php generate:changelog server v13.0.0 stable13
 ```
 
 E.g. generate the changelog for the upcoming 3.3.0 Android release:
 
 ```
-php index.php android generate:changelog stable-3.3.0 stable-3.3.x
+php index.php generate:changelog android stable-3.3.0 stable-3.3.x
 ```
 
 


### PR DESCRIPTION
The $repoName was in the wrong place in the examples in the README.