### PR TITLE
Set min supported node at 16

### DIFF
--- a/.github/workflows/dispatch-npm-engines.yml
+++ b/.github/workflows/dispatch-npm-engines.yml
@@ -49,7 +49,7 @@ jobs:
         repositories: ${{ fromJSON(needs.repositories.outputs.matrix) }}
 
     env:
-      NODE_VERSION: "^14.0.0"
+      NODE_VERSION: "^16.0.0"
       NPM_VERSION: "^7.0.0"
 
     steps:


### PR DESCRIPTION
https://github.com/nextcloud/standards/issues/1

Node 16 ships npm 8 since 16.11.0.
I suggest we just leave npm to 7.0.0 as this is the minimum supported. Devs can still use npm 8 if they want :)

Everyone on board?

@max-nextcloud @vinicius73 @artonge @CarlSchwan @JuliaKirschenheuter @GretaD @jotoeri @raimund-schluessler @korelstar @marcoambrosini @eneiluj 