### PR TITLE
Support npm 8

### DIFF
--- a/.github/workflows/dispatch-npm-engines.yml
+++ b/.github/workflows/dispatch-npm-engines.yml
@@ -50,7 +50,7 @@ jobs:
 
     env:
       NODE_VERSION: "^16.0.0"
-      NPM_VERSION: "^7.0.0"
+      NPM_VERSION: "^7.0.0 || ^8.0.0"
 
     steps:
       - name: Checkout target repository


### PR DESCRIPTION
So - to go on here, i now just create a PR. :wink:
I think this should be the way, that most of us can live with. Once Node 16 supports npm@9, everybody feel free, to create another PR if necessary. :+1: 

Just for reference: Discussions are in https://github.com/nextcloud/standards/discussions/6 and https://github.com/nextcloud/standards/discussions/7

I can create this PR, but i'm honestly not sure, who can dispatch it then. Most probably any repo-admin:
https://github.com/nextcloud/github_helper/blob/21dd8bc5296f42a498f2c65d018efc244695e4d1/.github/workflows/dispatch-npm-engines.yml#L21