### PR TITLE
fix(changelog): do not consider PRs against milestone X.0.1 relevant to major  X

### DIFF
--- a/changelog/index.php
+++ b/changelog/index.php
@@ -334,7 +334,7 @@ class GenerateChangelogCommand extends Command
 
 				$response = $client->api('graphql')->execute($query);
 				foreach ($response['data']['repository']['milestones']['nodes'] as $milestone) {
-					if (strpos($milestone['title'], $milestoneToCheck) !== false) {
+					if ($milestone['title'] === \sprintf('Nextcloud %s', $milestoneToCheck)) {
 						foreach ($milestone['pullRequests']['nodes'] as $pr) {
 							if ($this->shouldPRBeSkipped($pr)) {
 								continue;


### PR DESCRIPTION
It's about pending PRs. Currently, any PR against 27.0.1 would be listed as pending for the major release (as well as for pre-releases).