### PR TITLE
chore(npm): npm 9 is EOL

### DIFF
--- a/.github/workflows/dispatch-npm-engines.yml
+++ b/.github/workflows/dispatch-npm-engines.yml
@@ -50,7 +50,7 @@ jobs:
 
     env:
       NODE_VERSION: "^20.0.0"
-      NPM_VERSION: "^9.0.0"
+      NPM_VERSION: "^10.0.0"
 
     steps:
       - name: Checkout target repository


### PR DESCRIPTION
NPM 9 is EOL October 2023: https://github.com/npm/statusboard/issues/443 