### PR TITLE
fix(Changelog): resort to name alternatives if commit's author info is not given

### DIFF
--- a/changelog/index.php
+++ b/changelog/index.php
@@ -310,7 +310,7 @@ class GenerateChangelogCommand extends Command
 				}
 
 				foreach ($commits as $commit) {
-					$login = $commit['author']['login'];
+					$login = $commit['author']['login'] ?? $commit['committer']['login'] ?? $commit['commit']['author']['name'];
 					$fullMessage = $commit['commit']['message'];
 					list($firstLine,) = explode("\n", $fullMessage, 2);
 					if (substr($firstLine, 0, 20) === 'Merge pull request #') {


### PR DESCRIPTION
Happened to me today for the infos on those commits:

- https://api.github.com/repos/nextcloud/server/commits/8d22d341c80b8d7c791e57829ef244d97d3fa4f1
author is null

- https://api.github.com/repos/nextcloud/bruteforcesettings/git/commits/165a830994c7727a80bfe3d49bc6b19aeefde96c
author and committer are null