### PR TITLE
fix(spdx-converter): check all kind of JS files and HTML files

### DIFF
--- a/spdx-convertor/convert.php
+++ b/spdx-convertor/convert.php
@@ -309,7 +309,7 @@ foreach ($finder->getIterator() as $file) {
 		} else {
 			echo " ├─ 🔶 \033[0;33m" . $file->getRealPath() . ' skipped' . "\033[0m\n";
 		}
-	} elseif ($file->getExtension() === 'js' || $file->getExtension() === 'ts') {
+	} elseif (preg_match('/^[mc]?[tj]s$/', $file->getExtension())) {
 		if (
 			!str_contains($file->getRealPath(), '/vendor/')
 		) {
@@ -317,7 +317,7 @@ foreach ($finder->getIterator() as $file) {
 		} else {
 			echo " ├─ 🔶 \033[0;33m" . $file->getRealPath() . ' skipped' . "\033[0m\n";
 		}
-	} elseif ($file->getExtension() === 'vue') {
+	} elseif ($file->getExtension() === 'vue' || $file->getExtension() === 'html') {
 		if (
 			!str_contains($file->getRealPath(), '/vendor/')
 		) {


### PR DESCRIPTION
- `mts`, `mjs`, `cjs`, `cts` files are missing for JS/TS files
- `html` is missing (same as Vue, as .vue file is a .html file by syntax)