### PR TITLE
fix(spdx-converter): glob processing of *

### DIFF
--- a/spdx-convertor/convert.php
+++ b/spdx-convertor/convert.php
@@ -281,7 +281,7 @@ if (file_exists($path . '.reuse/dep5')) {
 		foreach ($files as $file) {
 			$pathFilter = $file;
 			if (str_contains($file, '*')) {
-				$pathFilter = '/'. str_replace(['/', '.', '*'], ['\/', '\.', '(.+)'], $file) . '$/i';
+				$pathFilter = '/'. str_replace(['/', '.', '*'], ['\/', '\.', '(.*)'], $file) . '$/i';
 			}
 			$finder->notPath($pathFilter);
 		}


### PR DESCRIPTION
As I understand, `*` in glob means `any number of any characters including none`, not `one or more any characters`