### PR TITLE
chore: update current node to 22 lts

### DIFF
--- a/.github/workflows/dispatch-npm-engines.yml
+++ b/.github/workflows/dispatch-npm-engines.yml
@@ -51,7 +51,7 @@ jobs:
         repositories: ${{ fromJSON(needs.repositories.outputs.matrix) }}
 
     env:
-      NODE_VERSION: "^20.0.0"
+      NODE_VERSION: "^22.0.0"
       NPM_VERSION: "^10.0.0"
       BRANCH_NAME: "feat/package-node-npm-engines-update"
 


### PR DESCRIPTION
See https://github.com/nextcloud/standards/issues/5 update from today

Npm 11 is out, but still not set as default
![image](https://github.com/user-attachments/assets/0ab51e55-db80-4b8b-a91e-c28c49e312b5)
