### PR TITLE
fix(changelog): fix new-app stdout pollution and wrong release title

### DIFF
--- a/changelog/index.php
+++ b/changelog/index.php
@@ -293,6 +293,8 @@ class GenerateChangelogCommand extends Command
 			$output->writeln('<error>No version detected - the output will not contain any pending PRs. Use a git tag starting with "v" like "v13.0.5".</error>');
 		}
 
+		$displayVersion = (substr($head, 0, 1) === 'v') ? substr($head, 1) : ($milestoneToCheck ?? $head);
+
 		$prTitles = ['closed' => [], 'pending' => []];
 
 		# TODO
@@ -351,17 +353,13 @@ class GenerateChangelogCommand extends Command
 				$effectiveBase = $info['default_branch'];
 			}
 			if (in_array($repoName, $newApps)) {
-				$output->writeln('<info>' . $repoName . ' is new in this release.</info>');
-				// print 3 empty lines to not overwrite the message with the progress bar
-				$output->writeln('');
-				$output->writeln('');
-				$output->writeln('');
 				$prTitles['closed'][$repoName . '#0'] = [
 					'repoName' => $repoName,
 					'number' => 0,
 					'title' => 'Newly added in this release',
 					'newApp' => true,
 				];
+				$progressBar->setMessage("$repoName is new in this release.");
 				$progressBar->advance();
 				continue;
 			}
@@ -542,7 +540,7 @@ QUERY;
 
 		switch ($format) {
 			case 'html':
-				$version = $milestoneToCheck;
+				$version = $displayVersion;
 				$versionDashed = str_replace('.', '-', $version);
 				$date = new \DateTime('now');
 				$date = $date->add(new \DateInterval('P1D'));
@@ -577,7 +575,7 @@ QUERY;
 				break;
 			case 'forum':
 				// Making it a second heading as the first one is the title of the post
-				$output->writeln("## Nextcloud " . $milestoneToCheck);
+				$output->writeln("## Nextcloud " . $displayVersion);
 				$closedPRs = $this->groupPRsByRepo($prTitles['closed']);
 				foreach ($closedPRs as $repo => $prs) {
 					$output->writeln("\n### [$repo](https://github.com/$orgName/$repo)");
@@ -595,7 +593,7 @@ QUERY;
 				break;
 			case 'markdown':
 			default:
-				$output->writeln("## Nextcloud " . $milestoneToCheck);
+				$output->writeln("## Nextcloud " . $displayVersion);
 				$closedPRs = $this->groupPRsByRepo($prTitles['closed']);
 				foreach ($closedPRs as $repo => $prs) {
 					$output->writeln("\n### [$repo](https://github.com/$orgName/$repo)");


### PR DESCRIPTION
## What

Two bugs introduced with the new-app detection feature (merged in #159):

**1. Extraneous lines before the changelog heading**

For each newly-shipped app, the generator called `$output->writeln('<info>...')` + 3 blank `writeln('')` (a progress-bar workaround) on the **same stdout stream** as the changelog content. When the output is captured/redirected, those lines appear *before* `## Nextcloud X.Y.Z`.

Confirmed in the v34.0.0 release body:
```
files_lock is new in this release.



office is new in this release.




## Nextcloud 33.0.6
```

Fix: replace with `$progressBar->setMessage()` — info stays in the progress bar, nothing written to the changelog output stream.

**2. Wrong release title**

`$milestoneToCheck` is derived from `$base` (next patch after the base tag). For a cross-major run (`base=v33.0.x`, `head=v34.0.0`) this gives `## Nextcloud 33.0.6` instead of `## Nextcloud 34.0.0`.

Fix: introduce `$displayVersion = ltrim($head, 'v')` and use it for all three format headings (`html`, `forum`, `markdown`). `$milestoneToCheck` is kept as-is for the GitHub milestone API query.

## Testing

- Cross-major: `base=v33.0.0 head=v34.0.0 --format=markdown` → heading is `## Nextcloud 34.0.0`, no text lines before it
- Patch: `base=v33.0.3 head=v33.0.4 --format=html` → heading/download links still say `33.0.4`